### PR TITLE
fix: add missing includes

### DIFF
--- a/wkbre2/file.h
+++ b/wkbre2/file.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/wkbre2/gameset/GameObjBlueprint.h
+++ b/wkbre2/gameset/GameObjBlueprint.h
@@ -7,6 +7,7 @@
 #include "../util/GSFileParser.h"
 //#include "gameset.h"
 #include <map>
+#include <cstdint>
 #include <string>
 #include <vector>
 #include "../util/IndexedStringList.h"

--- a/wkbre2/interface/QuickStartMenu.h
+++ b/wkbre2/interface/QuickStartMenu.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 #include "QuickSkirmishMenu.h"


### PR DESCRIPTION
# Fix

When building with the `make` instructions in the
readme on ubuntu 24.04, you get the following
compiler error:

```
file.h:49:9: note: 'uint32_t' is defined in header
'<cstdint>'; did you forget to '#include <cstdint>'?
```

Note that this commit does actually make building
on ubuntu 24.04 work, as you get this error
instead:

```
gfx/bitmap.cpp:13:10: fatal error:
stb_image_resize2.h: No such file or directory
```