### PR TITLE
ci: build on ubuntu with GCC

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,20 @@
+﻿name: Main
+
+on: push
+
+jobs:
+  ubuntu:
+    name: Ubuntu
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        compiler: ["gcc",]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+      - name: Install dependencies
+        run: ./continuous-integration/ubuntu-24.04/setup.sh
+      - name: "Build with ${{ matrix.compiler }}"
+        run:
+          uv run python continuous-integration/build.py
+            --compiler "${{ matrix.compiler }}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 ﻿# CMakeList.txt : fichier projet CMake de niveau supérieur, effectuez une configuration globale
 # et incluez les sous-projets ici.
 #
-cmake_minimum_required (VERSION 3.8)
+cmake_minimum_required (VERSION 3.19)
 
 project ("wkbre2")
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "configurePresets": [
+    {
+      "name": "vcpkg",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+      }
+    },
+    {
+      "name": "default",
+      "inherits": "vcpkg",
+      "environment": {
+        "VCPKG_ROOT": "build/3rdParty/vcpkg"
+      }
+    }
+  ]
+}

--- a/continuous-integration/build.py
+++ b/continuous-integration/build.py
@@ -1,0 +1,75 @@
+from argparse import ArgumentParser, Namespace
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from subprocess import run
+from os import environ
+
+
+@dataclass
+class _Compiler:
+    name: str
+    tool_path: Path
+
+
+_SUPPORTED_COMPILERS = (_Compiler(name="gcc", tool_path="g++"),)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).parent.parent
+
+
+def _select_compiler_from_string(string: str) -> _Compiler:
+    for compiler in _SUPPORTED_COMPILERS:
+        if compiler.name == string:
+            return compiler
+    raise ValueError(f"No compiler name matches: '{string}'")
+
+
+def _args() -> _Compiler:
+    parser = ArgumentParser()
+    parser.add_argument(
+        "--compiler",
+        choices=[compiler.name for compiler in _SUPPORTED_COMPILERS],
+        required=True,
+    )
+    arguments = parser.parse_args()
+    return _select_compiler_from_string(arguments.compiler)
+
+
+def _main() -> None:
+    selected_compiler = _args()
+
+    build_directory = _repo_root() / "build" / "ubuntu-24.04" / selected_compiler.name
+
+    environment = environ.copy()
+    vcpkg_root = _repo_root() / "build/3rdParty/vcpkg/"
+    environment["PATH"] = f"{environment['PATH']}:{vcpkg_root}"
+
+    cmake_configure_command = (
+        "cmake"
+        " --preset=default"
+        f' -B "{build_directory}"'
+        f" -DCMAKE_CXX_COMPILER={selected_compiler.tool_path}"
+    )
+    run(
+        cmake_configure_command,
+        capture_output=False,
+        check=True,
+        shell=True,
+        env=environment,
+    )
+
+    cmake_build_command = f"cmake --build {build_directory}"
+    print(f"Building with {selected_compiler.name}")
+    run(
+        cmake_build_command,
+        capture_output=False,
+        check=True,
+        shell=True,
+        env=environment,
+    )
+
+
+if __name__ == "__main__":
+    _main()

--- a/continuous-integration/ubuntu-24.04/install_dependencies.sh
+++ b/continuous-integration/ubuntu-24.04/install_dependencies.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT_DIR=$(cd "${SCRIPT_DIR}/../.." && pwd)
+
+# elevate privileges
+if [[ $EUID -ne 0 ]]; then
+  sudo "$0" "$@"
+  exit $?
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get --quiet update
+apt-get --quiet --assume-yes install \
+    cmake \
+    curl \
+    g++ \
+    git \
+    libbz2-dev \
+    libenet-dev \
+    libgl-dev \
+    libglew-dev \
+    libmpg123-dev \
+    libopenal-dev \
+    libsdl2-dev \
+    libxi-dev \
+    libxmu-dev \
+    ninja-build \
+    nlohmann-json3-dev \
+    wget \
+    zip

--- a/continuous-integration/ubuntu-24.04/install_uv.sh
+++ b/continuous-integration/ubuntu-24.04/install_uv.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -euo pipefail
+
+wget --quiet --output-document=- https://astral.sh/uv/install.sh | sh

--- a/continuous-integration/ubuntu-24.04/install_vcpkg.sh
+++ b/continuous-integration/ubuntu-24.04/install_vcpkg.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT_DIR=$(cd "${SCRIPT_DIR}/../.." && pwd)
+
+mkdir --parents "$REPO_ROOT_DIR/build/3rdParty"
+cd "$REPO_ROOT_DIR/build/3rdParty"
+git clone https://github.com/microsoft/vcpkg.git
+cd -
+
+"$REPO_ROOT_DIR/build/3rdParty/vcpkg/bootstrap-vcpkg.sh" -disableMetrics

--- a/continuous-integration/ubuntu-24.04/setup.sh
+++ b/continuous-integration/ubuntu-24.04/setup.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT_DIR=$(cd "${SCRIPT_DIR}/../.." && pwd)
+
+"$REPO_ROOT_DIR/continuous-integration/ubuntu-24.04/install_dependencies.sh"
+"$REPO_ROOT_DIR/continuous-integration/ubuntu-24.04/install_uv.sh"
+"$REPO_ROOT_DIR/continuous-integration/ubuntu-24.04/install_vcpkg.sh"

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,14 @@
+{
+  "default-registry": {
+    "kind": "git",
+    "baseline": "3af1d1e60af2b2abf55760538cd607829029b07a",
+    "repository": "https://github.com/microsoft/vcpkg"
+  },
+  "registries": [
+    {
+      "kind": "artifact",
+      "location": "https://github.com/microsoft/vcpkg-ce-catalog/archive/refs/heads/main.zip",
+      "name": "microsoft"
+    }
+  ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,9 @@
+{
+  "dependencies": [
+    "glew",
+    "lua",
+    "mpg123",
+    "sol2",
+    "stb"
+  ]
+}


### PR DESCRIPTION
# Motivation

To properly support ubuntu 24.04, building with `make` is not sufficient. Just managing the dependencies is difficult. Since this repository is already using `cmake` and `vcpkg` for building on windows, this commit is simply extending this for ubuntu-24.04.

To build locally, you simply need to run
`python continuous-integration/build.py` when you have all of the dependencies installed. These you can install by running `continuous-integration/ubuntu-24.04/setup.sh`.

Alternatively you can just do the same as the Github Actions workflow run and do the same as it does.

The usage of `ninja` as generator and `gcc` as compiler is completely arbitrary. However the setup is configured so that adding support for a different compiler such as `clang` could be done with minimal effort.

Since we now use `CMakePresets.json` to provide `vcpkg` to `CMake`, this forces a bump to `CMake` version 3.19.

# Rejected alternatives

The system dependencies that we rely on could be installed with `nix` + `devenv`, but I decided that this might be a bit too controversial/overkill for the initial ubuntu build.

Using `AppVeyor` to build targeting different platforms + compilers could be an option, however this is difficult for anyone that is not the repository owner to contribute, as the `AppVeyor` settings are not something that are visible to others.

By using `Github Actions` makes it possible for others that fork this repository to have working builds from the very start.

# Future work

This commit only ensures that the build actually succeeds, if the resulting artifacts can actually be run is a different task altogether.

There are a lot of compiler warnings like
```
warning: invalid use of incomplete type 'struct CommonGameState'
```

That is printed to stdout when building, but these would need to be addressed in a future commit.